### PR TITLE
Fix safe metric formatting for pandas inputs

### DIFF
--- a/App.py
+++ b/App.py
@@ -77,6 +77,8 @@ def last_val(df: pd.DataFrame, col: str) -> float:
         return np.nan
 
 def safe_metric_fmt(val, kind="num"):
+    """Format scalars for metric display while tolerating pandas objects."""
+    val = get_scalar(val)
     if not isinstance(val, (int, float, np.floating)) or np.isnan(val):
         return "N/A"
     if kind == "money_b":


### PR DESCRIPTION
## Summary
- ensure safe_metric_fmt normalizes pandas objects before formatting metrics to avoid ambiguous truth value errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5b1df0104832398c31cf4c13e6d43